### PR TITLE
Improve Unity Hub headless setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-`curl | bash` のワンライナーを叩くだけで、従来 **Windows 前提**とされていた VRChat 制作環境を **Ubuntu 22.04** に非対話で整えられます。  
+`curl | bash` のワンライナーを叩くだけで、従来 **Windows 前提**とされていた VRChat 制作環境を **Ubuntu 22.04** に非対話で整えられます。
 
 ```bash
 curl -sL https://raw.githubusercontent.com/KAFKA2306/UnityMCPforUbuntu22.04/main/install.sh | bash
 ```
 
--  **Unity Hub & Unity Editor 2022.3 LTS（ヘッドレス）** を自動インストール  
--  **vrc-get** で **SDK3 Worlds / Avatars + UdonSharp** を即投入  
--  **UnityMCP サーバー** を Node.js LTS 込みでビルド配置  
+-  **Unity Hub & Unity Editor 2022.3 LTS（ヘッドレス）** を自動インストール
+-  **vrc-get** で **SDK3 Worlds / Avatars + UdonSharp** を即投入
+-  **UnityMCP サーバー** を Node.js LTS 込みでビルド配置
 
-Unityhubとunityが連携しない助けて
+> **注意:** Unity Hub CLI でエディタを導入するには、あらかじめ Unity Hub GUI でサインインしライセンスを有効化しておく必要があります。  
+> このスクリプトは `dbus-run-session` を用いて Unity Hub を実行し、DBus セッションが存在しない環境でも headless インストールが行えるようになりました。
+

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,10 @@ PKGS=(vrc_sdk3-worlds vrc_sdk3-avatars udonsharp)
 # 依存ツール（xvfb で仮想Xを用意）
 echo "[*] Installing prerequisites…"
 sudo apt-get update -y
-sudo apt-get install -y ca-certificates curl gnupg xvfb
+sudo apt-get install -y ca-certificates curl gnupg xvfb dbus
+if ! sudo apt-get install -y libasound2; then
+  sudo apt-get install -y libasound2t64
+fi
 
 # Unity Hub インストール
 if ! command -v unityhub &>/dev/null; then
@@ -35,8 +38,9 @@ fi
 
 # Unity Hub ラッパー（xvfb-run + headless + errors）
 HUB() {
-  xvfb-run --auto-servernum --server-args='-screen 0 1280x1024x24' \
-    unityhub --headless --errors "$@"
+  dbus-run-session -- \
+    xvfb-run --auto-servernum --server-args='-screen 0 1280x1024x24' \
+      unityhub --headless --errors "$@"
 }
 
 # 対応 Unity Editor の導入（--changeset auto + linux-il2cpp）


### PR DESCRIPTION
## Summary
- Install audio and D-Bus dependencies before launching Unity Hub
- Run Unity Hub via `dbus-run-session` to provide a session bus in headless environments
- Document sign-in requirement and DBus handling in README

## Testing
- `bash install.sh >/tmp/install.log && tail -n 20 /tmp/install.log` *(fails: SSL handshake errors from unityhub)*

------
https://chatgpt.com/codex/tasks/task_e_68b1534404888325ba789c04963cfed6